### PR TITLE
Enable IBM Cloud App Configuration properties in the razee plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# This is an example configuration to enable detect-secrets in the pre-commit hook.
+# Add this file to the root folder of your repository.
+#
+# Read pre-commit hook framework https://pre-commit.com/ for more details about the structure of config yaml file and how git pre-commit would invoke each hook.
+#
+# This line indicates we will use the hook from ibm/detect-secrets to run scan during committing phase.
+# Whitewater/whitewater-detect-secrets would sync code to ibm/detect-secrets upon merge.
+repos:
+- repo: https://github.com/ibm/detect-secrets
+  # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
+  # You are encouraged to use static refs such as tags, instead of branch name
+  #
+  # Running "pre-commit autoupdate" would automatically updates rev to latest tag
+  rev: 0.13.1+ibm.34.dss
+  hooks:
+    -   id: detect-secrets # pragma: whitelist secret
+        # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.
+        # You may also run `pre-commit run detect-secrets` to preview the scan result.
+        # when "--baseline" without "--use-all-plugins", pre-commit scan with just plugins in baseline file
+        # when "--baseline" with "--use-all-plugins", pre-commit scan with all available plugins
+        # add "--fail-on-non-audited" to fail pre-commit for unaudited potential secrets
+        args: [--baseline, .secrets.baseline, --use-all-plugins ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,82 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2021-04-09T12:14:57Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GheDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "89a6cfe2a229151e8055abee107d45ed087bbb4f",
+        "is_verified": false,
+        "line_number": 297,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.34.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@razee/razeedeploy-core": "^0.8.2",
     "bunyan": "^1.8.12",
     "express": "^4.17.1",
-    "ibm-appconfiguration-node-sdk": "^1.0.1",
+    "ibm-appconfiguration-node-sdk": "^1.1.0",
     "node-fetch": "^2.6.0",
     "object-path": "^0.11.4"
   }

--- a/resource.yaml
+++ b/resource.yaml
@@ -44,7 +44,7 @@ items:
                       optional: true
               imagePullPolicy: Always
               name: appconfigibm-controller
-  - apiVersion: apiextensions.k8s.io/v1beta1
+  - apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
       # name must match the spec fields below, and be in the form: <plural>.<group>
@@ -59,6 +59,9 @@ items:
           served: true
           # One and only one version must be marked as the storage version.
           storage: true
+          subresources:
+            # status enables the status subresource
+            status: {}
           schema:
           # openAPIV3Schema is the schema for validating custom objects.
             openAPIV3Schema:
@@ -88,7 +91,7 @@ items:
                       type: string
                     apikey:
                       type: string
-                    apkeyRef:
+                    apikeyRef:
                       type: object
                       required: [valueFrom]
                       properties:
@@ -153,8 +156,5 @@ items:
         # shortNames allow shorter string to match your resource on the CLI
         shortNames:
           - icappconfig
-      subresources:
-        # status enables the status subresource
-        status: {}
       # prune unknown fields
       preserveUnknownFields: false


### PR DESCRIPTION
Changes
1. Support for properties to be available in the razee plugin. This change affects existing customers.
 -- The plugin adds prefix `flag-` and `prop-` to the keys for flags and properties respectively.
 -- For eg a flag with id `nginx-label` is available with the key `flag-nginx-label` and a property with id `nginx-label` is available with the key `prop-nginx-label`.
-- Existing customers need to add the prefix to the feature flag keys.
2. Custom Resource definition api is migrated to v1 from v1beta1. This removes the warning message for deprecated api while installing the IBM Cloud App Config plugin and also makes it ready for kubernetes 1.22 whenever it is released in the future.
3. README is updated with the changes related to properties.
Detect Secrets Proof
![image](https://user-images.githubusercontent.com/32262271/114180509-e5b84880-995d-11eb-81f7-76996e385a40.png)
![image](https://user-images.githubusercontent.com/32262271/114180525-e94bcf80-995d-11eb-97e0-296657ca7938.png)
